### PR TITLE
Fixed package.json libraries paths

### DIFF
--- a/lib/main.jsx
+++ b/lib/main.jsx
@@ -1,4 +1,5 @@
-import React from "react/react-with-addons";
+import React from "react";
+import addons from 'react-addons';
 
 var Hello = React.createClass({
   componentDidMount() {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "jspm": {
     "dependencies": {
-      "jsx": "npm:jsx-plugin@^0.0.3",
-      "react": "github:reactjs/react-bower@^0.12.2"
+      "jsx": "^0.1.1",
+      "react": "^0.12.2",
+      "react-addons": "npm:react-addons@^0.9.0"
     }
   }
 }


### PR DESCRIPTION
 * Use react from jspm registry
 * Use react-addons from npm (instead of react from bower)
 * Use jsx plugin from jspm registry